### PR TITLE
Fixed dispatchNestedScroll behavior of onTouchEvent.

### DIFF
--- a/lib/src/main/java/com/tobiasrohloff/view/NestedScrollWebView.java
+++ b/lib/src/main/java/com/tobiasrohloff/view/NestedScrollWebView.java
@@ -89,16 +89,12 @@ public class NestedScrollWebView extends WebView implements NestedScrollingChild
                     mNestedYOffset += mScrollOffset[1];
                 }
 
-                int oldY = getScrollY();
                 mLastMotionY = y - mScrollOffset[1];
-                if (deltaY < 0) {
-                    int newScrollY = Math.max(0, oldY + deltaY);
-                    deltaY -= newScrollY - oldY;
-                    if (dispatchNestedScroll(0, newScrollY - deltaY, 0, deltaY, mScrollOffset)) {
-                        mLastMotionY -= mScrollOffset[1];
-                        trackedEvent.offsetLocation(0, mScrollOffset[1]);
-                        mNestedYOffset += mScrollOffset[1];
-                    }
+				
+                if (dispatchNestedScroll(0, deltaY, 0, 0, mScrollOffset)) {
+                    mLastMotionY -= mScrollOffset[1];
+                    trackedEvent.offsetLocation(0, mScrollOffset[1]);
+                    mNestedYOffset += mScrollOffset[1];
                 }
 
                 result = super.onTouchEvent(trackedEvent);

--- a/lib/src/main/java/com/tobiasrohloff/view/NestedScrollWebView.java
+++ b/lib/src/main/java/com/tobiasrohloff/view/NestedScrollWebView.java
@@ -91,7 +91,12 @@ public class NestedScrollWebView extends WebView implements NestedScrollingChild
 
                 mLastMotionY = y - mScrollOffset[1];
 				
-                if (dispatchNestedScroll(0, deltaY, 0, 0, mScrollOffset)) {
+                int oldY = getScrollY();
+                int newScrollY = Math.max(0, oldY + deltaY);
+                int dyConsumed = newScrollY - oldY;
+                int dyUnconsumed = deltaY - dyConsumed;
+
+                if (dispatchNestedScroll(0, dyConsumed, 0, dyUnconsumed, mScrollOffset)) {
                     mLastMotionY -= mScrollOffset[1];
                     trackedEvent.offsetLocation(0, mScrollOffset[1]);
                     mNestedYOffset += mScrollOffset[1];


### PR DESCRIPTION
Hello.

We recently implemented your NestedScrollWebView in our App to fix a problem with touch gestures not being recognized in embedded content. While this problem was fixed, we found that the NestScrollWebView introduced a new bug where our floating action button didn't behave as before. After some investigation, I found out that the dyConsumed values sent by NestedScrollWebView didn't fit to what our button expects. I closely analyzed NestedScrollWebView and some of the calculations in there didn't really make sense to me. Hence, I made a fix which works flawlessly for us. Here is the pull request. Maybe you find it useful as a general fix for the component:

Explanation:

First of all, the (delta < 0) check causes the NSWebView to only ever dispatch events when the user scrolls up. Our button expects events for either scroll direction, however (and I'd wager this is a general expectation).

Secondly, the calculation of the second parameter that is passed into dispatchNestedScroll didn't make sense to me.  As far as I understood the documentation, the parameter should be the consumed pixels that were scrolled by the movement. I fixed and cleaned up the calculation of both, dyConsumed and dyUnconsumed and improved the variable naming, to improve readability of this part of the function.

PS: Please don't look at the first commit by itself. I still had some oversights in there.